### PR TITLE
增加插件 `NapCatQQ`

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -238,5 +238,9 @@
     {
         "repo": "adproqwq/LiteLoaderQQNT-Kemisago",
         "branch": "main"
+    },
+    {
+        "repo": "NapNeko/NapCatQQ",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
[NapCatQQ](https://github.com/NapNeko/NapCatQQ) abbr. NCQQ 是知名的基于 NTQQ 的 Bot 框架之一，原本为"无头"启动 QQ 的框架，自版本 V2 起增加了 `Framework` 启动模式，可作为 LiteLoaderQQNT 插件加载。

在扫清了[下载插件版本的最后一个障碍](https://github.com/ltxhhz/LL-plugin-list-viewer/pull/34)后，NCQQ 终于做好了加入 Plugin-List 的准备。