### PR TITLE
添加插件 LiteLoaderQQNT-AutoForward

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -322,5 +322,9 @@
     {
         "repo": "WJZ-P/LiteLoaderQQNT-Stick-Emoji",
         "branch": "main"
+    },
+    {
+        "repo": "WongJingGitt/LiteLoaderQQNT-AutoForward",
+        "branch": "master"
     }
 ]


### PR DESCRIPTION
根据设定的规则自动转发QQ消息至指定的好友、群聊或群内成员，支持多种匹配模式和消息预处理选项。
https://github.com/WongJingGitt/LiteLoaderQQNT-AutoForward