### PR TITLE
移除 Stapxs QQ Theme

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -240,10 +240,6 @@
         "branch": "main"
     },
     {
-        "repo": "Stapxs/Stapxs-QQ-Lite-Theme",
-        "branch": "main"
-    },
-    {
         "repo": "NapNeko/NapCatQQ",
         "branch": "main"
     },


### PR DESCRIPTION
主题不再更新，不保证后续版本的兼容；为了减少麻烦主动移出目录。