### PR TITLE
chore: update plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -5,19 +5,19 @@
     },
     {
         "repo": "MUKAPP/LiteLoaderQQNT-MSpring-Theme",
-        "branch": "v4"
+        "branch": "v5"
     },
     {
         "repo": "PRO-2684/Scriptio",
-        "branch": "main"
+        "branch": "v1.4.5"
     },
     {
         "repo": "PRO-2684/transitio",
-        "branch": "main"
+        "branch": "v1.5.7"
     },
     {
         "repo": "xiyuesaves/LiteLoaderQQNT-lite_tools",
-        "branch": "v4"
+        "branch": "dev/v5"
     },
     {
         "repo": "mo-jinran/window-on-top",


### PR DESCRIPTION
1. MSpring-Theme 已将默认分支替换为 v5
2. Scriptio 已经不再支持 LLQQNT
3. 同上
4. LiteLoaderQQNT-lite_tools v4 分支以及停止活动